### PR TITLE
FUL-35529 Update sample to the newset version of connector framework …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/gradle/src
 RUN --mount=type=cache,target=/home/gradle/.gradle gradle --parallel -S --no-daemon distTar
 
 ## Build production image with only outputs
-FROM quay.io/beekeeper/integration-connector-base:0.5.9
+FROM quay.io/beekeeper/integration-connector-base:0.6.3
 
 LABEL Description="Sample User Sync Connector"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-sdkVersion=0.5.9
+sdkVersion=0.6.3
 jacksonVersion=2.12.3

--- a/usersync-sample/src/test/java/io/beekeeper/connector/usersync/sample/ExampleUserRestService.java
+++ b/usersync-sample/src/test/java/io/beekeeper/connector/usersync/sample/ExampleUserRestService.java
@@ -31,7 +31,7 @@ public class ExampleUserRestService {
         wireMock = new WireMockServer(
                 options()
                     .dynamicPort()
-                    .withRootDirectory("src/test/resources/exampleUserRestService")
+                    .withRootDirectory("usersync-sample/src/test/resources/exampleUserRestService")
         );
         stubExternalApi();
         stubGetToken();


### PR DESCRIPTION
…and fix a mock service.

The mock service got broken when we added a directory usersync-sample, and the path to a resource file changed.