### PR TITLE
[TPA-87] Adjust sample connector's content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax = docker/dockerfile:1.0-experimental
 # Build with multistage build on jdk-17
 FROM gradle:7.6.0-jdk17 as java_build
 

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/ApiClientFactory.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/ApiClientFactory.java
@@ -12,6 +12,10 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Factory for building authenticated API clients for the API.
+ * Configures authentication, HTTP client, and Retrofit with Jackson serialization.
+ */
 @AllArgsConstructor
 public class ApiClientFactory {
     final String baseUrlString;

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/ResponseBody.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/ResponseBody.java
@@ -6,9 +6,13 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * Wrapper for Sample API paginated response.
+ * Deserializes the JSON response containing user data.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ResponseBody {
     @Getter
     @JsonProperty("content")
-    private List<SampleUser> users;
+    private List<SampleUserDto> users;
 }

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleApi.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleApi.java
@@ -2,10 +2,17 @@ package io.beekeeper.connector.usersync.sample;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Query;
 
+/**
+ * Retrofit HTTP interface for Sample API endpoints.
+ */
 public interface SampleApi {
 
     @GET("api/1/users")
-    Call<ResponseBody> getUsers();
+    Call<ResponseBody> getUsers(
+            @Query("limit") Integer limit,
+            @Query("offset") Integer offset
+    );
 
 }

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleConnector.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleConnector.java
@@ -12,7 +12,14 @@ import io.beekeeper.integration.connector.usersync.api.UserImportConfiguration;
 import io.beekeeper.integration.connector.usersync.api.UserImportConnector;
 import io.beekeeper.integration.connector.usersync.api.UserImportObserver;
 import io.beekeeper.integration.connector.usersync.api.UserImportResult;
+import io.beekeeper.integration.connector.usersync.api.data.UserData;
 
+import java.util.List;
+
+/**
+ * Main connector implementation for Sample API user synchronization.
+ * Orchestrates the user import flow with pagination support.
+ */
 public class SampleConnector implements UserImportConnector {
 
     private final ObjectMapper objectMapper;
@@ -36,8 +43,10 @@ public class SampleConnector implements UserImportConnector {
 
         SampleUserProvider userProvider = new SampleUserProvider(sampleImportConfiguration);
 
-        // All users have to be sent to the observer
-        observer.onNext(userProvider.fetchBatch());
+        List<UserData> batch;
+        while (!(batch = userProvider.fetchBatch()).isEmpty()) {
+            observer.onNext(batch);
+        }
 
         return new UserImportResult();
     }

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleDefaultMapping.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleDefaultMapping.java
@@ -4,7 +4,14 @@ import io.beekeeper.directorySync.mapping.field.external.ExternalField;
 import io.beekeeper.directorySync.mapping.field.external.IExternalField;
 import io.beekeeper.integration.connector.usersync.api.ConnectorDefaultMapping;
 
+/**
+ * Default field mapping configuration for Sample connector.
+ * Defines how external API fields are mapped to Beekeeper user properties.
+ * This class handles field-level mapping configuration only;
+ * data transformation logic is in {@link SampleUserForBeekeeperMapping}.
+ */
 public class SampleDefaultMapping implements ConnectorDefaultMapping {
+
     @Override
     public IExternalField getExternalUserId() {
         return ExternalField.builder()

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUser.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUser.java
@@ -1,6 +1,0 @@
-package io.beekeeper.connector.usersync.sample;
-
-import io.beekeeper.integration.connector.usersync.api.data.UserData;
-
-public class SampleUser extends UserData {
-}

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserDto.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserDto.java
@@ -1,0 +1,23 @@
+package io.beekeeper.connector.usersync.sample;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO for Sample API user response.
+ * Represents the raw data structure from the external API.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SampleUserDto {
+
+    private String id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private Boolean suspended;
+    private String position;
+
+}

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserForBeekeeperMapping.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserForBeekeeperMapping.java
@@ -1,0 +1,37 @@
+package io.beekeeper.connector.usersync.sample;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import io.beekeeper.integration.connector.usersync.api.data.UserData;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Transformation class that converts Sample API user DTOs into Beekeeper-compatible format.
+ * Extends UserData to provide the required properties for the Beekeeper system.
+ */
+@Getter
+@Setter
+public class SampleUserForBeekeeperMapping extends UserData {
+
+    @Override
+    @JsonAnySetter
+    public void setProperty(String attr, @Nullable Object value) {
+        super.setProperty(attr, value);
+    }
+
+    public static SampleUserForBeekeeperMapping fromUserDto(@NonNull SampleUserDto userDto) {
+        SampleUserForBeekeeperMapping mappedUser = new SampleUserForBeekeeperMapping();
+
+        mappedUser.setProperty("id", userDto.getId());
+        mappedUser.setProperty("firstName", userDto.getFirstName());
+        mappedUser.setProperty("lastName", userDto.getLastName());
+        mappedUser.setProperty("email", userDto.getEmail());
+        mappedUser.setProperty("suspended", userDto.getSuspended());
+        mappedUser.setProperty("position", userDto.getPosition());
+
+        return mappedUser;
+    }
+}

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserProvider.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/SampleUserProvider.java
@@ -3,50 +3,79 @@ package io.beekeeper.connector.usersync.sample;
 import io.beekeeper.connector.usersync.sample.config.SampleImportConfiguration;
 import io.beekeeper.integration.connector.api.exception.ConfigurationException;
 import io.beekeeper.integration.connector.api.exception.ImportProviderException;
+import io.beekeeper.integration.connector.usersync.api.data.UserData;
 import io.beekeeper.marketplace.sdk.utils.http.oauth2.OAuth2ProviderException;
 import retrofit2.Call;
 import retrofit2.Response;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Provider for fetching users from the Sample API with pagination support.
+ * Manages offset-based pagination state and batches user data retrieval.
+ */
 public class SampleUserProvider {
 
     final SampleApi sampleApi;
+    final Integer pageLimit;
+    private Integer currentOffset;
+    private Boolean hasMore;
 
     public SampleUserProvider(SampleImportConfiguration sampleImportConfiguration) {
         sampleApi = new ApiClientFactory(
                 sampleImportConfiguration.getBaseUrl(),
                 sampleImportConfiguration.getClientId(),
                 sampleImportConfiguration.getClientSecret()
-        )
-            .build();
+        ).build();
+
+        this.pageLimit = sampleImportConfiguration.getPageLimit();
+        this.hasMore = true;
+        this.currentOffset = 0;
     }
 
-    public List<SampleUser> fetchBatch() throws ImportProviderException {
+    public List<UserData> fetchBatch() throws ImportProviderException, ConfigurationException {
+        if (!hasMore) {
+            return Collections.emptyList();
+        }
+
         try {
-            final Call<ResponseBody> workers = sampleApi.getUsers();
-            final Response<ResponseBody> response = workers.execute();
+            final Call<ResponseBody> usersCall = sampleApi.getUsers(pageLimit, currentOffset);
+            final Response<ResponseBody> response = usersCall.execute();
+
             if (!response.isSuccessful()) {
                 if (response.code() == 404) {
+                    hasMore = false;
                     return Collections.emptyList();
                 }
                 throw new ImportProviderException(
                         String.format(
-                            "Fetching workers failed because of an error: {} , code: {} "
+                            "Fetching users failed because of an error: {} , code: {} "
                                 + response.errorBody().toString()
                                 +
                                 +response.code()
                         )
                 );
             }
-            final ResponseBody responseBody = response.body();
 
-            return Optional.ofNullable(responseBody)
+            final ResponseBody responseBody = response.body();
+            List<SampleUserDto> userDtos = Optional.ofNullable(responseBody)
                 .map(ResponseBody::getUsers)
                 .orElse(Collections.emptyList());
+
+            hasMore = userDtos.size() >= pageLimit;
+            currentOffset += pageLimit;
+
+            List<UserData> transformedUsers = new ArrayList<>();
+            for (SampleUserDto userDto : userDtos) {
+                transformedUsers.add(SampleUserForBeekeeperMapping.fromUserDto(userDto));
+            }
+
+            return transformedUsers;
+
         } catch (OAuth2ProviderException e) {
             throw new ConfigurationException("Incorrect credentials", e);
         } catch (IOException e) {

--- a/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/config/SampleImportConfiguration.java
+++ b/usersync-sample/src/main/java/io/beekeeper/connector/usersync/sample/config/SampleImportConfiguration.java
@@ -3,14 +3,20 @@ package io.beekeeper.connector.usersync.sample.config;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Configuration for Sample connector tenant-specific settings.
+ */
 @Getter
 @Setter
 public class SampleImportConfiguration {
+    static final int DEFAULT_PAGE_LIMIT = 50;
 
     private String baseUrl;
 
     private String clientId;
 
     private String clientSecret;
+
+    private Integer pageLimit = DEFAULT_PAGE_LIMIT;
 
 }

--- a/usersync-sample/src/test/resources/exampleUserRestService/__files/getUsersResponse.json
+++ b/usersync-sample/src/test/resources/exampleUserRestService/__files/getUsersResponse.json
@@ -4,13 +4,15 @@
     "id":"someid",
     "firstName":"winnie",
     "lastName":"thepooh",
-    "suspended":"false",
+    "email":"winnie@example.com",
+    "suspended":false,
     "position":"teddybear"
   }, {
     "id":"anotherid",
     "firstName":"frodo",
     "lastName":"baggins",
-    "suspended":"false",
+    "email":"frodo@example.com",
+    "suspended":false,
     "position":"hobbit"
   }]
 }

--- a/usersync-sample/src/test/resources/testCases/happyPath/tenant_baseUrl/mappings/api_1_users-7265d21d-2722-4490-b9c8-7da219272b8d.json
+++ b/usersync-sample/src/test/resources/testCases/happyPath/tenant_baseUrl/mappings/api_1_users-7265d21d-2722-4490-b9c8-7da219272b8d.json
@@ -2,12 +2,12 @@
   "id" : "7265d21d-2722-4490-b9c8-7da219272b8d",
   "name" : "api_1_users",
   "request" : {
-    "url" : "/api/1/users",
+    "urlPath" : "/api/1/users",
     "method" : "GET"
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "ewogICJjb250ZW50IjogWwogICAgewogICAgImlkIjoic29tZWlkIiwKICAgICJmaXJzdE5hbWUiOiJ3aW5uaWUiLAogICAgImxhc3ROYW1lIjoidGhlcG9vaCIsCiAgICAic3VzcGVuZGVkIjoiZmFsc2UiLAogICAgInBvc2l0aW9uIjoidGVkZHliZWFyIgogIH0sIHsKICAgICJpZCI6ImFub3RoZXJpZCIsCiAgICAiZmlyc3ROYW1lIjoiZnJvZG8iLAogICAgImxhc3ROYW1lIjoiYmFnZ2lucyIsCiAgICAic3VzcGVuZGVkIjoiZmFsc2UiLAogICAgInBvc2l0aW9uIjoiaG9iYml0IgogIH1dCn0=",
+    "base64Body" : "ewogICJjb250ZW50IjogWwogICAgewogICAgImlkIjoic29tZWlkIiwKICAgICJmaXJzdE5hbWUiOiJ3aW5uaWUiLAogICAgImxhc3ROYW1lIjoidGhlcG9vaCIsCiAgICAiZW1haWwiOiJ3aW5uaWVAZXhhbXBsZS5jb20iLAogICAgInN1c3BlbmRlZCI6ZmFsc2UsCiAgICAicG9zaXRpb24iOiJ0ZWRkeWJlYXIiCiAgfSwgewogICAgImlkIjoiYW5vdGhlcmlkIiwKICAgICJmaXJzdE5hbWUiOiJmcm9kbyIsCiAgICAibGFzdE5hbWUiOiJiYWdnaW5zIiwKICAgICJlbWFpbCI6ImZyb2RvQGV4YW1wbGUuY29tIiwKICAgICJzdXNwZW5kZWQiOmZhbHNlLAogICAgInBvc2l0aW9uIjoiaG9iYml0IgogIH1dCn0K",
     "headers" : {
       "Matched-Stub-Id" : "c8dc5107-80bb-4848-900b-296b7e3f5345",
       "Vary" : "Accept-Encoding, User-Agent",


### PR DESCRIPTION
- add descriptions for classes and interfaces of the sample connector
- extract UserDto to a separate class
- add pagination example
- change 'SampleUser' to 'SampleUserForBeekeeperMapping' and add the `setProperty` method for building the fields
- adjust the tests to changes